### PR TITLE
Additional logic for TLS and area for certs loading from dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 druid-exporter
+*.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ MAINTAINER OpsTree Solutions
 WORKDIR /app
 RUN apk add --no-cache libc6-compat
 COPY --from=builder /go/src/druid-exporter/druid-exporter /app/
+COPY --from=builder /go/src/druid-exporter/* /app/
 ENTRYPOINT ["./druid-exporter"]

--- a/cert/README.md
+++ b/cert/README.md
@@ -1,0 +1,1 @@
+Add certs to this directory to allow docker to place them inside the image


### PR DESCRIPTION
Adding an additional step where there is no client side but TLS verify is being used on the server 