### PR TITLE
fix druid_emitted_metrics issue

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/inconshreveable/log15 v0.0.0-20170622235902-74a0988b5f80/go.mod h1:cO
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/grafana_dashboards/dashboard.json
+++ b/grafana_dashboards/dashboard.json
@@ -163,7 +163,7 @@
         "timeFrom": null,
         "timeShift": null,
         "title": "Druid Cluster Health",
-        "type": "singlestat",
+        "type": "stat",
         "valueFontSize": "80%",
         "valueMaps": [
           {
@@ -300,7 +300,7 @@
         "pluginVersion": "6.5.2",
         "targets": [
           {
-            "expr": "count(druid_tasks) by (task_status)",
+            "expr": "count(druid_tasks_duration) by (task_status)",
             "legendFormat": "{{task_status}}",
             "refId": "A"
           }

--- a/listener/druid_endpoint.go
+++ b/listener/druid_endpoint.go
@@ -46,12 +46,12 @@ func DruidHTTPEndpoint(gauge *prometheus.GaugeVec) http.HandlerFunc {
 						}
 					}
 					for _, datasource := range datasources {
+						podName := collector.ToPodName(strings.Split(host, ":")[0])
 						gauge.With(prometheus.Labels{
 							"metric_name": strings.Replace(metricName, "/", "-", 3),
 							"service":     strings.Replace(serviceName, "/", "-", 3),
-							"host":        host,
 							"datasource":  datasource,
-							"pod":         collector.ToPodName(strings.Split(host, ":")[0]),
+							"pod":         podName,
 						}).Set(value)
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "druid_emitted_metrics",
 			Help: "Druid emitted metrics from druid emitter",
-		}, []string{"pod", "metric_name", "service", "host", "datasource"},
+		}, []string{"pod", "metric_name", "service", "datasource"},
 	)
 )
 


### PR DESCRIPTION
if druid-coordinator restart, the host will change, and metric will remain forever and cause bugs.
