### PR TITLE
Bug fix for missing druid datasource in emitted metrics

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/inconshreveable/log15 v0.0.0-20170622235902-74a0988b5f80/go.mod h1:cO
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/listener/druid_endpoint.go
+++ b/listener/druid_endpoint.go
@@ -54,6 +54,18 @@ func DruidHTTPEndpoint(gauge *prometheus.GaugeVec) http.HandlerFunc {
 							"pod":         collector.ToPodName(strings.Split(host, ":")[0]),
 						}).Set(value)
 					}
+				} else {
+					metricName := fmt.Sprintf("%v", data["metric"])
+					serviceName := fmt.Sprintf("%v", data["service"])
+					host := fmt.Sprintf("%v", data["host"])
+					value, _ := strconv.ParseFloat(fmt.Sprintf("%v", data["value"]), 64)
+					gauge.With(prometheus.Labels{
+						"metric_name": strings.Replace(metricName, "/", "-", 3),
+						"service":     strings.Replace(serviceName, "/", "-", 3),
+						"host":        host,
+						"datasource":  "<nil>",
+						"pod":         collector.ToPodName(strings.Split(host, ":")[0]),
+					}).Set(value)
 				}
 			}
 			logrus.Debugf("Successfully collected data from druid emitter")


### PR DESCRIPTION
Refer to #36. This is a bug fix to add an else case when druid does not emit datasource value.