### PR TITLE
deployment.yaml: treat DRUID_EXPORTER_PORT as string

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: DRUID_URL
           value: {{ .Values.druidURL }}
         - name: DRUID_EXPORTER_PORT
-          value: {{ .Values.druidExporterPort }}
+          value: {{ .Values.druidExporterPort | quote}}
         - name: LOG_LEVEL
           value: {{ .Values.logLevel }}
         - name: LOG_FORMAT


### PR DESCRIPTION
Currently, the default value on DRUID_EXPORTER_PORT is throwing an
error:

> helm upgrade --install druid-exporter druid/druid-exporter/helm/
--namespace druid

Release "druid-exporter" does not exist. Installing it
now.  Error: Deployment in version "v1" cannot be handled as a
Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template:
v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container:
v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or
n, but found 8, error found in #10 byte of ...|,"value":8080},{"nam|...,
bigger context
...|elabs.in"},{"name":"DRUID_EXPORTER_PORT","value":8080},{"name":"LOG_LEVEL","value":"info"},{"name":"|...

This is due to the ENV variable for port not being quoted, as
recommended [1]

[1] https://v2.helm.sh/docs/developing_charts/#quote-strings-don-t-quote-integers

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>