### PR TITLE
servicemonitor.yaml: correct casing for namespace helm variable

### DIFF
--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
     scrapeTimeout: 60s
   namespaceSelector:
     matchNames:
-    - {{ .Release.namespace }}
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
       druid: metrics


### PR DESCRIPTION
Currently, the namespace is resolved to 'nil'.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>