### PR TITLE
Add metric druid_worker_capacity_total

### DIFF
--- a/collector/interface.go
+++ b/collector/interface.go
@@ -41,6 +41,7 @@ type MetricCollector struct {
 	DruidWaitingTasks         *prometheus.Desc
 	DruidCompletedTasks       *prometheus.Desc
 	DruidPendingTasks         *prometheus.Desc
+	DruidWorkerCapacity       *prometheus.Desc
 }
 
 // DataSourcesTotalRows shows total rows from each datasource


### PR DESCRIPTION
Adds total worker capacity(total number of workers in the druid cluster) as a metric.
Resolves  #82 .