### PR TITLE
Add support for extra env vars

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
           value: {{ .Values.logFormat }}
         - name: NO_HISTOGRAM
           value: {{ .Values.noHistogram | quote}}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
 {{- if .Values.security.enabled }}
         - name: DRUID_USER
           value: {{ .Values.security.druidUser }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,8 @@ noHistogram: false
 
 exporterPort: 8080
 
+extraEnv: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This change could be quite handy when, for example, skipping TLS verification in presence of self-signed certificates. In values.yaml one could then have:

```
extraEnv:
  # -- Boolean flag to skip TLS verification
  - name: INSECURE_TLS_VERIFY
    value: "true"
```