### PR TITLE
[Helm][Add] Support for k8s affinity & tolerations / ServiceMonitor relabelings and metricRelabelings

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,10 +1,9 @@
 ---
 apiVersion: v1
-appVersion: "v0.10.0"
+appVersion: "v0.11.0"
 description: Druid exporter to monitor druid metrics with Prometheus
-engine: gotpl
 name: prometheus-druid-exporter
-version: 0.10.0
+version: 0.11.0
 home: https://github.com/opstree/druid-exporter
 maintainers:
 - email: abhishekbhardwaj510@gmail.com

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -63,3 +63,9 @@ spec:
       serviceAccount: {{ include "prometheus-druid-exporter.fullname" . }}
       serviceAccountName: {{ include "prometheus-druid-exporter.fullname" . }}
 {{- end }}
+{{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
+{{- end }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -20,6 +20,14 @@ spec:
     path: /metrics
     port: metrics
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .ValuesserviceMonitor.relabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -57,5 +57,14 @@ serviceMonitor:
   scrapeTimeout: 10s
   additionalLabels: {}
   targetLabels: []
+  # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+  relabelings: []
+  metricRelabelings: []
+    ## Solves conflict with the label 'service' set on the kube-prometehus-stack
+    # - sourceLabels:
+    #   - exported_service
+    #   targetLabel: druid_service
+    # - regex: exported_service
+    #   action: labeldrop
 
 testEnabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,12 +29,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 security:
   enabled: false
   druidUser: admin
-  druidPassword: 
+  druidPassword:
     value: admin
-    secretKeyRef: 
+    secretKeyRef:
       enabled: false
       secretName: mysecret
       secretKey: mysecretkey


### PR DESCRIPTION
Improved helm chart with the following:

* Bumping chart/app version to `0.11.0`
* Added support affinity and tolerations rules
* Added support for Prometheus relabeling and metric relabeling via Prometheus OP's `ServiceMonitor`